### PR TITLE
bump opensearch ref and uncomment observability

### DIFF
--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -17,27 +17,27 @@ module "kube-state-metrics" {
   namespace   = "md-observability"
 }
 
-# module "opensearch" {
-#   #   count              = var.observability.logging.destination == "opensearch" ? 1 : 0
-#   # Temporary workaround for having to comment out obervability param in massdriver.yaml
-#   count              = 0
-#   source             = "github.com/massdriver-cloud/terraform-modules//k8s-opensearch?ref=2400d29"
-#   md_metadata        = var.md_metadata
-#   release            = "opensearch"
-#   namespace          = "md-observability"
-#   kubernetes_cluster = local.kubernetes_cluster_artifact
-#   helm_additional_values = {
-#     persistence = {
-#       # Temporary workaround for having to comment out obervability param in massdriver.yaml
-#       #   size = var.observability.logging.opensearch.persistence_size
-#       size = "8Gi"
-#     }
-#   }
-#   enable_dashboards = true
-#   // this adds a retention policy to move indexes to warm after 1 day and delete them after a user configurable number of days
-#   ism_policies = {
-#     # Temporary workaround for having to comment out obervability param in massdriver.yaml
-#     # "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : var.observability.logging.opensearch.retention_days })
-#     "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : 7 })
-#   }
-# }
+module "opensearch" {
+  #   count              = var.observability.logging.destination == "opensearch" ? 1 : 0
+  # Temporary workaround for having to comment out obervability param in massdriver.yaml
+  count              = 0
+  source             = "github.com/massdriver-cloud/terraform-modules//k8s-opensearch?ref=c32a6dc"
+  md_metadata        = var.md_metadata
+  release            = "opensearch"
+  namespace          = "md-observability"
+  kubernetes_cluster = local.kubernetes_cluster_artifact
+  helm_additional_values = {
+    persistence = {
+      # Temporary workaround for having to comment out obervability param in massdriver.yaml
+      #   size = var.observability.logging.opensearch.persistence_size
+      size = "8Gi"
+    }
+  }
+  enable_dashboards = true
+  // this adds a retention policy to move indexes to warm after 1 day and delete them after a user configurable number of days
+  ism_policies = {
+    # Temporary workaround for having to comment out obervability param in massdriver.yaml
+    # "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : var.observability.logging.opensearch.retention_days })
+    "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : 7 })
+  }
+}


### PR DESCRIPTION
this bumps opensearch module ref to [commit](https://github.com/massdriver-cloud/terraform-modules/commit/c32a6dcfa81f11c07372aa6c3133da6e022f43c0) that downgrades to the old 3.1.0 tls provider that is used by the cached providers and was causing terraform validation issues.

Note. The observability section is still commented out in massdriver.yaml for the time being.