### PR TITLE
add opensearch / fluentbit for kube logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Form input parameters for configuring a bundle for deployment.
     - **`max_size`** *(integer)*: Maximum number of instances in the node group. Minimum: `0`. Default: `10`.
     - **`min_size`** *(integer)*: Minimum number of instances in the node group. Minimum: `0`. Default: `1`.
     - **`name_suffix`** *(string)*: The name of the node group. Default: ``.
+- **`observability`** *(object)*: Configure logging and metrics collection and delivery for your entire cluster.
+  - **`logging`** *(object)*: Configure logging for your cluster.
+    - **`destination`** *(string)*: Where to send logs. Default: `disabled`.
+      - **One of**
+        - OpenSearch (in cluster)
+        - Disabled
 ## Examples
 
   ```json

--- a/core-services/logging/fluentbit/filter.conf
+++ b/core-services/logging/fluentbit/filter.conf
@@ -1,0 +1,14 @@
+[FILTER]
+    Name                kubernetes
+    Match               kube.*
+    Merge_Log           On
+    Keep_Log            Off
+    K8S-Logging.Parser  On
+    K8S-Logging.Exclude On
+
+[FILTER]
+    Name                nest
+    Match               *
+    Operation           lift
+    Nested_under        kubernetes
+    Add_prefix          kubernetes_

--- a/core-services/logging/fluentbit/opensearch_output.conf.tftpl
+++ b/core-services/logging/fluentbit/opensearch_output.conf.tftpl
@@ -6,7 +6,8 @@
     HTTP_User admin
     HTTP_Passwd admin
     Logstash_Format True
-    Logstash_Prefix k8s-pod-logs
+    Logstash_Prefix namespace
+    Logstash_Prefix_Key kubernetes_namespace_name
     Retry_Limit False
     tls on
     tls.verify off

--- a/core-services/logging/fluentbit/opensearch_output.conf.tftpl
+++ b/core-services/logging/fluentbit/opensearch_output.conf.tftpl
@@ -1,0 +1,26 @@
+[OUTPUT]
+    Name  opensearch
+    Match kube.*
+    Host  opensearch-cluster-master.${namespace}.svc.cluster.local
+    Port  9200
+    HTTP_User admin
+    HTTP_Passwd admin
+    Logstash_Format True
+    Logstash_Prefix k8s-pod-logs
+    Retry_Limit False
+    tls on
+    tls.verify off
+    Suppress_Type_Name on
+[OUTPUT]
+    Name  opensearch
+    Match host.*
+    Host  opensearch-cluster-master.${namespace}.svc.cluster.local
+    Port  9200
+    HTTP_User admin
+    HTTP_Passwd admin
+    Logstash_Format True
+    Logstash_Prefix k8s-node-logs
+    Retry_Limit False
+    tls on
+    tls.verify off
+    Suppress_Type_Name on

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -31,7 +31,7 @@ module "opensearch" {
   kubernetes_cluster = local.kubernetes_cluster_artifact
   helm_additional_values = {
     persistence = {
-      size = var.observability.logging.opensearch.persistence_size
+      size = "${var.observability.logging.opensearch.persistence_size}Gi"
     }
   }
   enable_dashboards = true

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -50,6 +50,7 @@ module "fluentbit" {
   kubernetes_cluster = local.kubernetes_cluster_artifact
   helm_additional_values = {
     config = {
+      filters = file("${path.module}/logging/fluentbit/filter.conf")
       outputs = templatefile("${path.module}/logging/fluentbit/opensearch_output.conf.tftpl", {
         namespace = local.o11y_namespace
       })

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -1,3 +1,8 @@
+locals {
+  enable_opensearch = var.observability.logging.destination == "opensearch"
+  enable_fluentbit  = local.enable_opensearch
+  o11y_namespace    = "md-observability"
+}
 // Making this a hard-coded conditional for now, because once we support prometheus it will become conditional based on prometheus
 // since it is effectively replaced by the prometheus-adapter https://github.com/kubernetes-sigs/prometheus-adapter
 module "metrics-server" {
@@ -14,30 +19,40 @@ module "kube-state-metrics" {
   source      = "github.com/massdriver-cloud/terraform-modules//k8s-kube-state-metrics?ref=54da4ef"
   md_metadata = var.md_metadata
   release     = "kube-state-metrics"
-  namespace   = "md-observability"
+  namespace   = local.o11y_namespace
 }
 
-# module "opensearch" {
-#   #   count              = var.observability.logging.destination == "opensearch" ? 1 : 0
-#   # Temporary workaround for having to comment out obervability param in massdriver.yaml
-#   count              = 0
-#   source             = "github.com/massdriver-cloud/terraform-modules//k8s-opensearch?ref=2400d29"
-#   md_metadata        = var.md_metadata
-#   release            = "opensearch"
-#   namespace          = "md-observability"
-#   kubernetes_cluster = local.kubernetes_cluster_artifact
-#   helm_additional_values = {
-#     persistence = {
-#       # Temporary workaround for having to comment out obervability param in massdriver.yaml
-#       #   size = var.observability.logging.opensearch.persistence_size
-#       size = "8Gi"
-#     }
-#   }
-#   enable_dashboards = true
-#   // this adds a retention policy to move indexes to warm after 1 day and delete them after a user configurable number of days
-#   ism_policies = {
-#     # Temporary workaround for having to comment out obervability param in massdriver.yaml
-#     # "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : var.observability.logging.opensearch.retention_days })
-#     "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : 7 })
-#   }
-# }
+module "opensearch" {
+  count              = local.enable_opensearch ? 1 : 0
+  source             = "github.com/massdriver-cloud/terraform-modules//k8s-opensearch?ref=5fc9525"
+  md_metadata        = var.md_metadata
+  release            = "opensearch"
+  namespace          = local.o11y_namespace
+  kubernetes_cluster = local.kubernetes_cluster_artifact
+  helm_additional_values = {
+    persistence = {
+      size = var.observability.logging.opensearch.persistence_size
+    }
+  }
+  enable_dashboards = true
+  // this adds a retention policy to move indexes to warm after 1 day and delete them after a user configurable number of days
+  ism_policies = {
+    "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : var.observability.logging.opensearch.retention_days })
+  }
+}
+
+module "fluentbit" {
+  count              = local.enable_fluentbit ? 1 : 0
+  source             = "github.com/massdriver-cloud/terraform-modules//k8s-fluentbit?ref=f920d78"
+  md_metadata        = var.md_metadata
+  release            = "fluentbit"
+  namespace          = local.o11y_namespace
+  kubernetes_cluster = local.kubernetes_cluster_artifact
+  helm_additional_values = {
+    config = {
+      outputs = templatefile("${path.module}/logging/fluentbit/opensearch_output.conf.tftpl", {
+        namespace = local.o11y_namespace
+      })
+    }
+  }
+}

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -34,62 +34,62 @@ params:
     - node_groups
     - core_services
   properties:
-    # observability:
-    #   type: object
-    #   title: Observability
-    #   description: Configure logging and metrics collection and delivery for your entire cluster
-    #   required:
-    #     -  logging
-    #   properties:
-    #     logging:
-    #       type: object
-    #       title: Logging
-    #       description: Configure logging for your cluster
-    #       required:
-    #         - destination
-    #       properties:
-    #         destination:
-    #           type: string
-    #           title: Destination
-    #           description: Where to send logs
-    #           default: "disabled"
-    #           oneOf:
-    #           - title: "OpenSearch (in cluster)"
-    #             const: "opensearch"
-    #           - title: "Disabled"
-    #             const: "disabled"
-    #       dependencies:
-    #         destination:
-    #           oneOf:
-    #             - properties:
-    #                 destination:
-    #                   const: "opensearch"
-    #                 opensearch:
-    #                   type: object
-    #                   title: OpenSearch
-    #                   required:
-    #                     - persistence_size
-    #                     - retention_days
-    #                   properties:
-    #                     persistence_size:
-    #                       type: integer
-    #                       title: Persistence Size GiB
-    #                       description: Size of the persistent volume to use for OpenSearch
-    #                       minimum: 2
-    #                       maximum: 1000
-    #                       default: 10
-    #                     retention_days:
-    #                       type: integer
-    #                       title: Retention Days
-    #                       description: Number of days to retain logs and metrics in an OpenSearch Index
-    #                       minimum: 1
-    #                       maximum: 365
-    #                       default: 7
-    #               required:
-    #                 - opensearch
-    #             - properties:
-    #                 destination:
-    #                   const: "disabled"
+    observability:
+      type: object
+      title: Observability
+      description: Configure logging and metrics collection and delivery for your entire cluster
+      required:
+        -  logging
+      properties:
+        logging:
+          type: object
+          title: Logging
+          description: Configure logging for your cluster
+          required:
+            - destination
+          properties:
+            destination:
+              type: string
+              title: Destination
+              description: Where to send logs
+              default: "disabled"
+              oneOf:
+              - title: "OpenSearch (in cluster)"
+                const: "opensearch"
+              - title: "Disabled"
+                const: "disabled"
+          dependencies:
+            destination:
+              oneOf:
+                - properties:
+                    destination:
+                      const: "opensearch"
+                    opensearch:
+                      type: object
+                      title: OpenSearch
+                      required:
+                        - persistence_size
+                        - retention_days
+                      properties:
+                        persistence_size:
+                          type: integer
+                          title: Persistence Size GiB
+                          description: Size of the persistent volume to use for OpenSearch
+                          minimum: 2
+                          maximum: 1000
+                          default: 10
+                        retention_days:
+                          type: integer
+                          title: Retention Days
+                          description: Number of days to retain logs and metrics in an OpenSearch Index
+                          minimum: 1
+                          maximum: 365
+                          default: 7
+                  required:
+                    - opensearch
+                - properties:
+                    destination:
+                      const: "disabled"
     k8s_version:
       type: string
       title: Kubernetes Version
@@ -250,11 +250,9 @@ ui:
       items:
         ui:field: dnsZonesDropdown
         cloud: aws
-  # observability:
-  #   # TODO hiding observability until fluentbit is talking to opensearch making it usable
-  #   ui:widget: "hidden"
-  #   logging:
-  #     opensearch:
-  #       persistence_size:
-  #         ui:field: conversionFieldData
-  #       default: Gibabytes
+  observability:
+    logging:
+      opensearch:
+        persistence_size:
+          ui:field: conversionFieldData
+          default: Gibabytes

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -72,12 +72,10 @@ params:
                         - retention_days
                       properties:
                         persistence_size:
-                          type: integer
+                          type: string
                           title: Persistence Size GiB
                           description: Size of the persistent volume to use for OpenSearch
-                          minimum: 2
-                          maximum: 1000
-                          default: 10
+                          default: "10"
                         retention_days:
                           type: integer
                           title: Retention Days

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -72,10 +72,12 @@ params:
                         - retention_days
                       properties:
                         persistence_size:
-                          type: string
+                          type: integer
                           title: Persistence Size GiB
                           description: Size of the persistent volume to use for OpenSearch
-                          default: "10"
+                          minimum: 1
+                          maximum: 10000
+                          default: 10
                         retention_days:
                           type: integer
                           title: Retention Days
@@ -248,9 +250,3 @@ ui:
       items:
         ui:field: dnsZonesDropdown
         cloud: aws
-  observability:
-    logging:
-      opensearch:
-        persistence_size:
-          ui:field: conversionFieldData
-          default: Gibabytes


### PR DESCRIPTION
this is essentially the same thing to support logging with fluent / opensearch that we just did in GKE.