### PR TITLE
Service account update 1.24

### DIFF
--- a/core-services/_artifacts.tf
+++ b/core-services/_artifacts.tf
@@ -9,7 +9,7 @@ locals {
     }
     // We need to set the "user" here, but the token won't be generated til the next step
     user = {
-      token = lookup(data.kubernetes_secret.massdriver-cloud-provisioner_service-account_secret.data, "token")
+      token = lookup(kubernetes_secret_v1.massdriver-cloud-provisioner_token.data, "token")
     }
   }
   data_infrastructure = {

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -1,7 +1,7 @@
 locals {
   enable_opensearch = var.observability.logging.destination == "opensearch"
   enable_fluentbit  = local.enable_opensearch
-  o11y_namespace    = "md-observability"
+  observability_namespace = "md-observability"
 }
 // Making this a hard-coded conditional for now, because once we support prometheus it will become conditional based on prometheus
 // since it is effectively replaced by the prometheus-adapter https://github.com/kubernetes-sigs/prometheus-adapter
@@ -9,25 +9,25 @@ module "metrics-server" {
   count     = true ? 1 : 0
   source    = "github.com/massdriver-cloud/terraform-modules//k8s-metrics-server?ref=54da4ef"
   release   = "metrics-server"
-  namespace = "md-observability"
+  namespace = local.observability_namespace
 }
 
-// Making this a hard-coded conditional for now. Unless the user is running prometheus (or integrates an observability package like DD)
-// there isn't much point to this service.
-module "kube-state-metrics" {
-  count       = true ? 1 : 0
-  source      = "github.com/massdriver-cloud/terraform-modules//k8s-kube-state-metrics?ref=54da4ef"
-  md_metadata = var.md_metadata
-  release     = "kube-state-metrics"
-  namespace   = local.o11y_namespace
-}
+# // Making this a hard-coded conditional for now. Unless the user is running prometheus (or integrates an observability package like DD)
+# // there isn't much point to this service.
+# module "kube-state-metrics" {
+#   count       = true ? 1 : 0
+#   source      = "github.com/massdriver-cloud/terraform-modules//k8s-kube-state-metrics?ref=54da4ef"
+#   md_metadata = var.md_metadata
+#   release     = "kube-state-metrics"
+#   namespace   = local.observability_namespace
+# }
 
 module "opensearch" {
   count              = local.enable_opensearch ? 1 : 0
   source             = "github.com/massdriver-cloud/terraform-modules//k8s-opensearch?ref=5fc9525"
   md_metadata        = var.md_metadata
   release            = "opensearch"
-  namespace          = local.o11y_namespace
+  namespace          = local.observability_namespace
   kubernetes_cluster = local.kubernetes_cluster_artifact
   helm_additional_values = {
     persistence = {
@@ -46,14 +46,64 @@ module "fluentbit" {
   source             = "github.com/massdriver-cloud/terraform-modules//k8s-fluentbit?ref=f920d78"
   md_metadata        = var.md_metadata
   release            = "fluentbit"
-  namespace          = local.o11y_namespace
+  namespace          = local.observability_namespace
   kubernetes_cluster = local.kubernetes_cluster_artifact
   helm_additional_values = {
     config = {
       filters = file("${path.module}/logging/fluentbit/filter.conf")
       outputs = templatefile("${path.module}/logging/fluentbit/opensearch_output.conf.tftpl", {
-        namespace = local.o11y_namespace
+        namespace = local.observability_namespace
       })
     }
   }
+}
+
+locals {
+  enable_prometheus = var.observability.metrics.destination == "prometheus"
+  prometheus_values = {
+    alertmanager = {
+      config = {
+        receivers = [{
+          name = "massdriver-cloud"
+          webhook_configs = [{
+            url = var.md_metadata.observability.alarm_webhook_url
+            send_resolved = true
+            max_alerts = 1
+          }]
+        }]
+      }
+    }
+    prometheus = {
+      prometheusSpec = {
+        replicas = 2
+        resources = {
+          requests = {
+            memory = "400Mi"
+          }
+        }
+        retention = "${var.observability.metrics.prometheus.retention_days}d"
+        storageSpec = {
+          volumeClaimTemplate = {
+            spec = {
+              storageClassName = "gp2"
+              accessModes = ["ReadWriteOnce"]
+              resources = {
+                requests = {
+                  storage = var.observability.metrics.prometheus.persistence_size
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+module "prometheus" {
+  count = local.enable_prometheus ? 1 : 0
+  source = "github.com/massdriver-cloud/terraform-modules//k8s/k8s-kube-prometheus-stack?ref=ec00875"
+  release = "kube-prometheus-stack"
+  namespace = local.observability_namespace
+  helm_additional_values = local.prometheus_values
 }

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -1,11 +1,13 @@
-resource "kubernetes_service_account" "massdriver-cloud-provisioner" {
+resource "kubernetes_service_account_v1" "massdriver-cloud-provisioner" {
   metadata {
-    name   = "massdriver-cloud-provisioner"
-    labels = var.md_metadata.default_tags
+    name      = "massdriver-cloud-provisioner"
+    namespace = kubernetes_namespace_v1.md-core-services.metadata.0.name
+    labels    = var.md_metadata.default_tags
   }
+  automount_service_account_token = false
 }
 
-resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
+resource "kubernetes_cluster_role_binding_v1" "massdriver-cloud-provisioner" {
   metadata {
     name   = "massdriver-cloud-provisioner"
     labels = var.md_metadata.default_tags
@@ -17,14 +19,19 @@ resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.name
-    namespace = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.namespace
+    name      = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.name
+    namespace = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.namespace
   }
 }
 
-data "kubernetes_secret" "massdriver-cloud-provisioner_service-account_secret" {
+resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   metadata {
-    name   = kubernetes_service_account.massdriver-cloud-provisioner.default_secret_name
-    labels = var.md_metadata.default_tags
+    name      = "massdriver-cloud-provisioner-token"
+    namespace = kubernetes_namespace_v1.md-core-services.metadata.0.name
+    labels    = var.md_metadata.default_tags
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.name
+    }
   }
+  type = "kubernetes.io/service-account-token"
 }

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -39,7 +39,8 @@ params:
       title: Observability
       description: Configure logging and metrics collection and delivery for your entire cluster
       required:
-        -  logging
+        - logging
+        - metrics
       properties:
         logging:
           type: object
@@ -87,6 +88,55 @@ params:
                           default: 7
                   required:
                     - opensearch
+                - properties:
+                    destination:
+                      const: "disabled"
+        metrics:
+          type: object
+          title: Metrics
+          description: Configure metrics for your cluster
+          required:
+            - destination
+          properties:
+            destination:
+              type: string
+              title: Destination
+              description: Where to aggregate metrics
+              default: "disabled"
+              oneOf:
+              - title: "Prometheus (in cluster)"
+                const: "prometheus"
+              - title: "Disabled"
+                const: "disabled"
+          dependencies:
+            destination:
+              oneOf:
+                - properties:
+                    destination:
+                      const: "prometheus"
+                    prometheus:
+                      type: object
+                      title: Prometheus
+                      required:
+                        - persistence_size
+                        - retention_days
+                      properties:
+                        persistence_size:
+                          type: integer
+                          title: Persistence Size GiB
+                          description: Size of the persistent volume to use for Prometheus
+                          minimum: 1
+                          maximum: 10000
+                          default: 10
+                        retention_days:
+                          type: integer
+                          title: Retention Days
+                          description: Number of days to retain metrics in Prometheus
+                          minimum: 1
+                          maximum: 365
+                          default: 7
+                  required:
+                    - prometheus
                 - properties:
                     destination:
                       const: "disabled"


### PR DESCRIPTION
In 1.24 Kubernetes will no longer automatically create secrets (with a token) when you make a service account.  This breaks the current way we fetch the token since we *assume* the secret will be there (specifically by using the [`default_secret_name`](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account#default_secret_name) attribute which has now been deprecated and no longer works.

Instead we manually create the secret and associate it to the service account.