### PR TITLE
Update the token fetch from the k8s service account to reflect the 1.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Form input parameters for configuring a bundle for deployment.
       "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
       ```
 
-- **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.19', '1.20', '1.21', '1.22']`.
+- **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.19', '1.20', '1.21', '1.22', '1.23']`.
 - **`node_groups`** *(array)*
   - **Items** *(object)*: Definition of a node group.
     - **`instance_type`** *(string)*: Instance type to use in the node group.
@@ -171,11 +171,6 @@ Connections from other bundles that this bundle depends on.
         "us-west-2"
         ```
 
-      - **`resource`** *(string)*
-      - **`service`** *(string)*
-      - **`zone`** *(string)*: AWS Availability Zone.
-
-        Examples:
 - **`vpc`** *(object)*: . Cannot contain additional properties.
   - **`data`** *(object)*
     - **`infrastructure`** *(object)*
@@ -297,11 +292,6 @@ Connections from other bundles that this bundle depends on.
         "us-west-2"
         ```
 
-      - **`resource`** *(string)*
-      - **`service`** *(string)*
-      - **`zone`** *(string)*: AWS Availability Zone.
-
-        Examples:
 <!-- CONNECTIONS:END -->
 
 </details>

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Resources created by this bundle that can be connected to other bundles.
             "https://massdriver.cloud"
             ```
 
-        - Azure Infrastructure Resource ID*object*: Minimal Azure Infrastructure Config. Cannot contain additional properties.
+        - Infrastructure Config*object*: Azure AKS Infrastructure Configuration. Cannot contain additional properties.
           - **`ari`** *(string)*: Azure Resource ID.
 
             Examples:
@@ -347,6 +347,7 @@ Resources created by this bundle that can be connected to other bundles.
             "/subscriptions/12345678-1234-1234-abcd-1234567890ab/resourceGroups/resource-group-name/providers/Microsoft.Network/virtualNetworks/network-name"
             ```
 
+          - **`oidc_issuer_url`** *(string)*
         - GCP Infrastructure GRN*object*: Minimal GCP Infrastructure Config. Cannot contain additional properties.
           - **`grn`** *(string)*: GCP Resource Name (GRN).
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Form input parameters for configuring a bundle for deployment.
       "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
       ```
 
-- **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.19', '1.20', '1.21', '1.22', '1.23']`.
+- **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.21', '1.22', '1.23', '1.24']`.
 - **`node_groups`** *(array)*
   - **Items** *(object)*: Definition of a node group.
     - **`instance_type`** *(string)*: Instance type to use in the node group.
@@ -96,18 +96,12 @@ Form input parameters for configuring a bundle for deployment.
     - **`max_size`** *(integer)*: Maximum number of instances in the node group. Minimum: `0`. Default: `10`.
     - **`min_size`** *(integer)*: Minimum number of instances in the node group. Minimum: `0`. Default: `1`.
     - **`name_suffix`** *(string)*: The name of the node group. Default: ``.
-- **`observability`** *(object)*: Configure logging and metrics collection and delivery for your entire cluster.
-  - **`logging`** *(object)*: Configure logging for your cluster.
-    - **`destination`** *(string)*: Where to send logs. Default: `disabled`.
-      - **One of**
-        - OpenSearch (in cluster)
-        - Disabled
 ## Examples
 
   ```json
   {
       "__name": "Development",
-      "k8s_version": "1.21",
+      "k8s_version": "1.24",
       "node_groups": [
           {
               "instance_type": "t3.medium",
@@ -122,7 +116,7 @@ Form input parameters for configuring a bundle for deployment.
   ```json
   {
       "__name": "Production",
-      "k8s_version": "1.21",
+      "k8s_version": "1.24",
       "node_groups": [
           {
               "instance_type": "c5.2xlarge",

--- a/core-services/_artifacts.tf
+++ b/core-services/_artifacts.tf
@@ -9,7 +9,7 @@ locals {
     }
     // We need to set the "user" here, but the token won't be generated til the next step
     user = {
-      token = lookup(data.kubernetes_secret.massdriver-cloud-provisioner_service-account_secret.data, "token")
+      token = lookup(kubernetes_secret_v1.massdriver-cloud-provisioner_token.data, "token")
     }
   }
   data_infrastructure = {

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -1,15 +1,17 @@
-locals {
-  enable_opensearch = var.observability.logging.destination == "opensearch"
-  enable_fluentbit  = local.enable_opensearch
-  o11y_namespace    = "md-observability"
+resource "kubernetes_namespace_v1" "md-observability" {
+  metadata {
+    labels = var.md_metadata.default_tags
+    name   = "md-observability"
+  }
 }
+
 // Making this a hard-coded conditional for now, because once we support prometheus it will become conditional based on prometheus
 // since it is effectively replaced by the prometheus-adapter https://github.com/kubernetes-sigs/prometheus-adapter
 module "metrics-server" {
   count     = true ? 1 : 0
   source    = "github.com/massdriver-cloud/terraform-modules//k8s-metrics-server?ref=54da4ef"
   release   = "metrics-server"
-  namespace = "md-observability"
+  namespace = kubernetes_namespace_v1.md-observability.metadata.0.name
 }
 
 // Making this a hard-coded conditional for now. Unless the user is running prometheus (or integrates an observability package like DD)
@@ -19,41 +21,5 @@ module "kube-state-metrics" {
   source      = "github.com/massdriver-cloud/terraform-modules//k8s-kube-state-metrics?ref=54da4ef"
   md_metadata = var.md_metadata
   release     = "kube-state-metrics"
-  namespace   = local.o11y_namespace
-}
-
-module "opensearch" {
-  count              = local.enable_opensearch ? 1 : 0
-  source             = "github.com/massdriver-cloud/terraform-modules//k8s-opensearch?ref=5fc9525"
-  md_metadata        = var.md_metadata
-  release            = "opensearch"
-  namespace          = local.o11y_namespace
-  kubernetes_cluster = local.kubernetes_cluster_artifact
-  helm_additional_values = {
-    persistence = {
-      size = "${var.observability.logging.opensearch.persistence_size}Gi"
-    }
-  }
-  enable_dashboards = true
-  // this adds a retention policy to move indexes to warm after 1 day and delete them after a user configurable number of days
-  ism_policies = {
-    "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : var.observability.logging.opensearch.retention_days })
-  }
-}
-
-module "fluentbit" {
-  count              = local.enable_fluentbit ? 1 : 0
-  source             = "github.com/massdriver-cloud/terraform-modules//k8s-fluentbit?ref=f920d78"
-  md_metadata        = var.md_metadata
-  release            = "fluentbit"
-  namespace          = local.o11y_namespace
-  kubernetes_cluster = local.kubernetes_cluster_artifact
-  helm_additional_values = {
-    config = {
-      filters = file("${path.module}/logging/fluentbit/filter.conf")
-      outputs = templatefile("${path.module}/logging/fluentbit/opensearch_output.conf.tftpl", {
-        namespace = local.o11y_namespace
-      })
-    }
-  }
+  namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
 }

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -1,11 +1,13 @@
-resource "kubernetes_service_account" "massdriver-cloud-provisioner" {
+resource "kubernetes_service_account_v1" "massdriver-cloud-provisioner" {
   metadata {
-    name   = "massdriver-cloud-provisioner"
-    labels = var.md_metadata.default_tags
+    name      = "massdriver-cloud-provisioner"
+    namespace = kubernetes_namespace_v1.md-core-services.metadata.0.name
+    labels    = var.md_metadata.default_tags
   }
+  automount_service_account_token = false
 }
 
-resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
+resource "kubernetes_cluster_role_binding_v1" "massdriver-cloud-provisioner" {
   metadata {
     name   = "massdriver-cloud-provisioner"
     labels = var.md_metadata.default_tags
@@ -17,14 +19,19 @@ resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.name
-    namespace = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.namespace
+    name      = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.name
+    namespace = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.namespace
   }
 }
 
-data "kubernetes_secret" "massdriver-cloud-provisioner_service-account_secret" {
+resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   metadata {
-    name   = kubernetes_service_account.massdriver-cloud-provisioner.default_secret_name
-    labels = var.md_metadata.default_tags
+    name      = "massdriver-cloud-provisioner-token"
+    namespace = kubernetes_namespace_v1.md-core-services.metadata.0.name
+    labels    = var.md_metadata.default_tags
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.name
+    }
   }
+  type = "kubernetes.io/service-account-token"
 }

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -35,34 +35,3 @@ resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   }
   type = "kubernetes.io/service-account-token"
 }
-
-////////////////////////////////////////////////////////////////
-/////////////// DELETE AFTER SENDING UPDATE ////////////////////
-////////////////////////////////////////////////////////////////
-// Leaving these resources in so that user's existing kubeconfigs
-// continue to work. We should send an update to inform them they'll
-// need to re-deploy and update their kubeconfig
-resource "kubernetes_service_account" "massdriver-cloud-provisioner" {
-  metadata {
-    name   = "massdriver-cloud-provisioner"
-    labels = var.md_metadata.default_tags
-  }
-}
-
-resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
-  metadata {
-    name   = "massdriver-cloud-provisioner"
-    labels = var.md_metadata.default_tags
-  }
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "ClusterRole"
-    name      = "cluster-admin"
-  }
-  subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.name
-    namespace = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.namespace
-  }
-}
-////////////////////////////////////////////////////////////////

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -35,3 +35,34 @@ resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   }
   type = "kubernetes.io/service-account-token"
 }
+
+////////////////////////////////////////////////////////////////
+/////////////// DELETE AFTER SENDING UPDATE ////////////////////
+////////////////////////////////////////////////////////////////
+// Leaving these resources in so that user's existing kubeconfigs
+// continue to work. We should send an update to inform them they'll
+// need to re-deploy and update their kubeconfig
+resource "kubernetes_service_account" "massdriver-cloud-provisioner" {
+  metadata {
+    name   = "massdriver-cloud-provisioner"
+    labels = var.md_metadata.default_tags
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
+  metadata {
+    name   = "massdriver-cloud-provisioner"
+    labels = var.md_metadata.default_tags
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.name
+    namespace = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.namespace
+  }
+}
+////////////////////////////////////////////////////////////////

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -16,14 +16,14 @@ steps:
 params:
   examples:
     - __name: Development
-      k8s_version: "1.21"
+      k8s_version: "1.24"
       node_groups:
         - name_suffix: shared
           instance_type: t3.medium
           min_size: 1
           max_size: 10
     - __name: Production
-      k8s_version: "1.21"
+      k8s_version: "1.24"
       node_groups:
         - name_suffix: shared
           instance_type: c5.2xlarge
@@ -34,72 +34,15 @@ params:
     - node_groups
     - core_services
   properties:
-    observability:
-      type: object
-      title: Observability
-      description: Configure logging and metrics collection and delivery for your entire cluster
-      required:
-        -  logging
-      properties:
-        logging:
-          type: object
-          title: Logging
-          description: Configure logging for your cluster
-          required:
-            - destination
-          properties:
-            destination:
-              type: string
-              title: Destination
-              description: Where to send logs
-              default: "disabled"
-              oneOf:
-              - title: "OpenSearch (in cluster)"
-                const: "opensearch"
-              - title: "Disabled"
-                const: "disabled"
-          dependencies:
-            destination:
-              oneOf:
-                - properties:
-                    destination:
-                      const: "opensearch"
-                    opensearch:
-                      type: object
-                      title: OpenSearch
-                      required:
-                        - persistence_size
-                        - retention_days
-                      properties:
-                        persistence_size:
-                          type: integer
-                          title: Persistence Size GiB
-                          description: Size of the persistent volume to use for OpenSearch
-                          minimum: 1
-                          maximum: 10000
-                          default: 10
-                        retention_days:
-                          type: integer
-                          title: Retention Days
-                          description: Number of days to retain logs and metrics in an OpenSearch Index
-                          minimum: 1
-                          maximum: 365
-                          default: 7
-                  required:
-                    - opensearch
-                - properties:
-                    destination:
-                      const: "disabled"
     k8s_version:
       type: string
       title: Kubernetes Version
       description: The version of Kubernetes to run
       enum:
-        - "1.19"
-        - "1.20"
         - "1.21"
         - "1.22"
         - "1.23"
+        - "1.24"
     node_groups:
       type: array
       title: Node Groups
@@ -271,7 +214,6 @@ ui:
     - k8s_version
     - node_groups
     - core_services
-    - observability
     - "*"
   node_groups:
     items:

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -3,7 +3,7 @@ name: aws-eks-cluster
 description: Elastic Kubernetes Service is an open source container orchestration platform that automates many of the manual processes involved in deploying, managing, and scaling containerized applications.
 source_url: github.com/massdriver-cloud/aws-eks-cluster
 access: public
-type: bundle
+type: infrastructure
 
 steps:
   - path: src


### PR DESCRIPTION
In 1.24 Kubernetes will no longer automatically create secrets (with a token) when you make a service account. This breaks the current way we fetch the token since we assume the secret will be there (specifically by using the [default_secret_name](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account#default_secret_name) attribute which has now been deprecated and no longer works.

Instead we manually create the secret and associate it to the service account.