### PR TITLE
add 'wait_for_service_account_token' to prevent errors on lookup

### DIFF
--- a/core-services/_artifacts.tf
+++ b/core-services/_artifacts.tf
@@ -9,7 +9,7 @@ locals {
     }
     // We need to set the "user" here, but the token won't be generated til the next step
     user = {
-      token = lookup(kubernetes_secret_v1.massdriver-cloud-provisioner_token.data, "token")
+      token = lookup(data.kubernetes_secret_v1.massdriver-cloud-provisioner_token.data, "token")
     }
   }
   data_infrastructure = {

--- a/core-services/_artifacts.tf
+++ b/core-services/_artifacts.tf
@@ -9,7 +9,7 @@ locals {
     }
     // We need to set the "user" here, but the token won't be generated til the next step
     user = {
-      token = lookup(data.kubernetes_secret_v1.massdriver-cloud-provisioner_token.data, "token")
+      token = lookup(kubernetes_secret_v1.massdriver-cloud-provisioner_token.data, "token")
     }
   }
   data_infrastructure = {

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -33,5 +33,6 @@ resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
       "kubernetes.io/service-account.name" = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.name
     }
   }
-  type = "kubernetes.io/service-account-token"
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
 }

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -36,11 +36,3 @@ resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   type                           = "kubernetes.io/service-account-token"
   wait_for_service_account_token = true
 }
-
-// Doing a data lookup after secret creation so we can get the generated token
-data "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
-  metadata {
-    name      = kubernetes_secret_v1.massdriver-cloud-provisioner_token.metadata.0.name
-    namespace = kubernetes_secret_v1.massdriver-cloud-provisioner_token.metadata.0.namespace
-  }
-}

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -36,3 +36,10 @@ resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   type                           = "kubernetes.io/service-account-token"
   wait_for_service_account_token = true
 }
+
+// Doing a data lookup after secret creation so we can get the generated token
+data "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
+  metadata {
+    name = kubernetes_secret_v1.massdriver-cloud-provisioner_token.metadata.0.name
+  }
+}

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -40,6 +40,7 @@ resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
 // Doing a data lookup after secret creation so we can get the generated token
 data "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   metadata {
-    name = kubernetes_secret_v1.massdriver-cloud-provisioner_token.metadata.0.name
+    name      = kubernetes_secret_v1.massdriver-cloud-provisioner_token.metadata.0.name
+    namespace = kubernetes_secret_v1.massdriver-cloud-provisioner_token.metadata.0.namespace
   }
 }


### PR DESCRIPTION
This issue I think: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1943

The creation of the token is eventually consistent. Sometimes the token lookup will cause an error. I'm hoping the `wait_for_service_account_token` will fix this (even though the docs say it already is defaulted to `true`).

Edit: This doesn't fix it, trying a data lookup instead.