### PR TITLE
Use a custom launch template for EKS nodes groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,27 @@ Form input parameters for configuring a bundle for deployment.
 
   ```json
   {
+      "__name": "Wizard",
+      "core_services": {
+          "enable_efs_csi": false,
+          "enable_ingress": true,
+          "route53_hosted_zones": []
+      },
+      "k8s_version": "1.24",
+      "node_groups": [
+          {
+              "advanced_configuration_enabled": false,
+              "instance_type": "t3.medium",
+              "max_size": 10,
+              "min_size": 1,
+              "name_suffix": "shared"
+          }
+      ]
+  }
+  ```
+
+  ```json
+  {
       "__name": "Development",
       "k8s_version": "1.24",
       "node_groups": [


### PR DESCRIPTION
Still testing that this doesn't have unintended consequences, but I wanted to get some eyes on it.  The benefits of these changes are a few things:

* By using a launch template we can specify the tags for instances, ENIs, EBS volumes, etc. all associated with node groups (and previously untaggable). Note, this doesn't include persistent volumes claims (dynamic storage), only default instance storage.
* By using a launch template we can also disable IMDSv1 ([which was the cause of CapitalOne's massive breach back in 2019](https://divvycloud.com/capital-one-data-breach-anniversary/))
* Long term benefit - it gives us greater control of instances in the future if we need it.

The are two drawbacks:

* This change is destructive to existing node groups. The good news here is that since `create_before_destroy` is `true`, terrafrom tries to create the new node group first, and fails due to a name collision with the existing node group.  What this means is that the migration is 2 steps: first duplicate all your node group configs and re-deploy (this will successfully create new nodes, but fail to destroy the old ones), then remove the old node groups from the config and deploy again.
* When the launch template was previously unspecified, EKS handles a lot of this launch template config "behind the scenes". By taking ownership we also take responsibility for the config. The good news here is that it seems anything left "unspecified" in the launch template still defaults back to the standard EKS options.  This is what I'm still testing.