### PR TITLE
Fargate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Form input parameters for configuring a bundle for deployment.
       "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
       ```
 
+- **`fargate`** *(object)*: AWS Fargate provides on-demand, right-sized compute capacity for running containers on EKS without managing node pools or clusters of EC2 instances.
+  - **`enabled`** *(boolean)*: Enables EKS Fargate. Default: `False`.
 - **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.22', '1.23', '1.24', '1.25', '1.26', '1.27']`. Default: `1.27`.
 - **`node_groups`** *(array)*
   - **Items** *(object)*: Definition of a node group.

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -23,6 +23,23 @@ module "prometheus-observability" {
   md_metadata = var.md_metadata
   release     = "massdriver"
   namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
+  helm_additional_values = {
+    prometheus-node-exporter = {
+      affinity = {
+        nodeAffinity = {
+          requiredDuringSchedulingIgnoredDuringExecution = {
+            nodeSelectorTerms = [{
+              matchExpressions = [{
+                key      = "eks.amazonaws.com/compute-type"
+                operator = "NotIn"
+                values   = ["fargate"]
+              }]
+            }]
+          }
+        }
+      }
+    }
+  }
 
   // prometheus requires persistent storage, which is managed by the EBS addon. This is more important on destruction since
   // volumes won't unbind properly if the EBS CSI driver is uninstalled before the volume, blocking destruction indefinitely.

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -45,6 +45,7 @@ params:
     - k8s_version
     - node_groups
     - core_services
+
   properties:
     k8s_version:
       type: string
@@ -58,6 +59,33 @@ params:
         - "1.25"
         - "1.26"
         - "1.27"
+    fargate:
+      type: object
+      title: Fargate
+      description: AWS Fargate provides on-demand, right-sized compute capacity for running containers on EKS without managing node pools or clusters of EC2 instances.
+      dependencies:
+        enabled:
+          oneOf:
+            - properties:
+                enabled:
+                  const: false
+            - required:
+                - namespace
+              properties:
+                enabled:
+                  const: true
+                namespace:
+                  type: string
+                  title: Fargate Namespace
+                  description: The namespace Fargate will schedule pods in.
+                  default: default
+      properties:
+        enabled:
+          type: boolean
+          default: false
+          title: Enable
+          description: Enables EKS Fargate
+          # TODO: select namespace
     node_groups:
       type: array
       title: Node Groups
@@ -228,7 +256,6 @@ params:
                         message:
                           pattern: Must be a valid AWS EFS file system ARN
 
-
 connections:
   required:
     - aws_authentication
@@ -249,6 +276,7 @@ artifacts:
 ui:
   ui:order:
     - k8s_version
+    - fargate
     - node_groups
     - core_services
     - "*"

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -70,7 +70,7 @@ params:
                 enabled:
                   const: false
             - required:
-                - namespace
+                - namespaces
               properties:
                 enabled:
                   const: true

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -74,18 +74,23 @@ params:
               properties:
                 enabled:
                   const: true
-                namespace:
-                  type: string
-                  title: Fargate Namespace
-                  description: The namespace Fargate will schedule pods in.
-                  default: default
+                namespaces:
+                  type: array
+                  items:
+                    $ref: https://raw.githubusercontent.com/massdriver-cloud/json-schemas/main/k8s/namespace.json
+                  minItems: 1
+                  uniqueItems: true
+                  title: Fargate Namespaces
+                  description: Namespaces that will run in Fargate
+                  default:
+                    - default
+
       properties:
         enabled:
           type: boolean
           default: false
           title: Enable
           description: Enables EKS Fargate
-          # TODO: select namespace
     node_groups:
       type: array
       title: Node Groups

--- a/operator.md
+++ b/operator.md
@@ -33,6 +33,16 @@ If users associate one or more Route53 domains to their EKS cluster, this bundle
 ### EFS CSI Driver
 Optionally, users can also install the [EFS CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html) which will allow the EKS cluster to attach EFS volumes to cluster workloads for persistant storage. EFS volumes offer some benefits over EBS volumes, such as [allowing multiple pods to use the volume simultaneously (ReadWriteMany)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) and not being being locked to a single AWS availability zone, but these benefits come with higher storage costs and increased latency.
 
+### Fargate
+
+Fargate can be enabled to allow AWS to provide on-demand, right-sized compute capacity for running containers on EKS without managing node pools or clusters of EC2 instances.
+
+For workloads that require high uptime, its recommended to keep some node pools populated even when enabling Fargate to ensure compute is always available during surges.
+
+Fargate has many [limitations](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html).
+
+Currently only `namespace` selectors are implemented. If you need `label` selectors please file an [issue](https://github.com/massdriver-cloud/aws-eks-cluster/issues).
+
 ## Best Practices
 ### Managed Node Groups
 Worker nodes in the cluster are provisioned as [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html).

--- a/src/fargate.tf
+++ b/src/fargate.tf
@@ -26,14 +26,14 @@ resource "aws_iam_role_policy_attachment" "amazon_eks_fargate_pod_execution_role
 }
 
 resource "aws_eks_fargate_profile" "default" {
-  count = var.fargate.enabled ? 1 : 0
+  for_each = toset(var.fargate.namespaces)
 
   cluster_name           = aws_eks_cluster.cluster.name
-  fargate_profile_name   = "${local.cluster_name}-fargate"
+  fargate_profile_name   = "${local.cluster_name}-fargate-${each.key}"
   pod_execution_role_arn = one(aws_iam_role.fargate[*].arn)
   subnet_ids             = local.private_subnet_ids
 
   selector {
-    namespace = var.fargate.namespace
+    namespace = each.key
   }
 }

--- a/src/fargate.tf
+++ b/src/fargate.tf
@@ -1,0 +1,39 @@
+data "aws_iam_policy_document" "assume_role" {
+  count = var.fargate.enabled ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["eks-fargate-pods.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "fargate" {
+  count              = var.fargate.enabled ? 1 : 0
+  name               = "${local.cluster_name}-fargate"
+  assume_role_policy = one(data.aws_iam_policy_document.assume_role[*].json)
+}
+
+resource "aws_iam_role_policy_attachment" "amazon_eks_fargate_pod_execution_role" {
+  count = var.fargate.enabled ? 1 : 0
+
+  policy_arn = "arn:${one(data.aws_partition.current[*].partition)}:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
+  role       = one(aws_iam_role.fargate[*].name)
+}
+
+resource "aws_eks_fargate_profile" "default" {
+  count = var.fargate.enabled ? 1 : 0
+
+  cluster_name           = aws_eks_cluster.cluster.name
+  fargate_profile_name   = "${local.cluster_name}-fargate"
+  pod_execution_role_arn = one(aws_iam_role.fargate[*].arn)
+  subnet_ids             = local.private_subnet_ids
+
+  selector {
+    namespace = var.fargate.namespace
+  }
+}


### PR DESCRIPTION
This adds support for scheduling workloads on fargate nodes. Currently only implements `namespace` selector.

Also renamed operator.md so we aren't using mdx