### PR TITLE
Adds support for passing through hosted zone prefix and suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Form input parameters for configuring a bundle for deployment.
       "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
       ```
 
+  - **`route53_hosted_zones_txt_prefix`** *(string)*: A prefix that is added to the name of the TXT records that are used to keep track of DNS entries that are added. This helps avoid name collisions with TXT records that may already exist in the hosted zone. Default: `edns.`.
+  - **`route53_hosted_zones_txt_suffix`** *(string)*: A suffix that is added to the name of the TXT records that are used to keep track of DNS entries that are added. This helps avoid name collisions with TXT records that may already exist in the hosted zone. Default: ``.
 - **`fargate`** *(object)*: AWS Fargate provides on-demand, right-sized compute capacity for running containers on EKS without managing node pools or clusters of EC2 instances.
   - **`enabled`** *(boolean)*: Enables EKS Fargate. Default: `False`.
 - **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.22', '1.23', '1.24', '1.25', '1.26', '1.27']`. Default: `1.27`.

--- a/core-services/core_services.tf
+++ b/core-services/core_services.tf
@@ -80,6 +80,10 @@ module "external_dns" {
   release              = "external-dns"
   namespace            = kubernetes_namespace_v1.md-core-services.metadata.0.name
   route53_hosted_zones = local.route53_zone_to_domain_map
+  helm_additional_values = {
+    txtPrefix = var.core_services.route53_hosted_zones_txt_prefix
+    txtSuffix = var.core_services.route53_hosted_zones_txt_suffix
+  }
 
   depends_on = [module.prometheus-observability]
 }

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -246,6 +246,16 @@ params:
             description: ""
             # TODO: Require a HostedZone ARN: arn:aws:route53:::hostedzone/Z0267127WDKJABXSA830 which isnt _quite a standard ARN.
             $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/aws-arn.json
+        route53_hosted_zones_txt_prefix:
+          type: string
+          title: Route53 Hosted Zones TXT Prefix
+          description: A prefix that is added to the name of the TXT records that are used to keep track of DNS entries that are added. This helps avoid name collisions with TXT records that may already exist in the hosted zone.
+          default: "edns."
+        route53_hosted_zones_txt_suffix:
+          type: string
+          title: Route53 Hosted Zones TXT Suffix
+          description: A suffix that is added to the name of the TXT records that are used to keep track of DNS entries that are added. This helps avoid name collisions with TXT records that may already exist in the hosted zone.
+          default: ""
         enable_efs_csi:
           type: boolean
           title: Enable EFS Volume Support


### PR DESCRIPTION
Allows specifying values for the `edns` `--txt-prefix` and `--txt-suffix` parameters. The default value for `--txt-prefix` is set to `edns.` to avoid collisions with any non-A records that may already exist in the hosted zone for the specified domain name.

TODO: Once massdriver-cloud/terraform-modules#198 is merged, then the [`source` used for the `external_dns` module](https://github.com/corgibytes/aws-eks-cluster/blob/485fd55455c2112b5b06e97422c78079cdd8cdfb/core-services/core_services.tf#L77) needs to be updated to reference a git sha that includes the merged pull request. This should not be merged in before that happens, because doing so will cause errors.

Depends on massdriver-cloud/terraform-modules#198
Fixes #55.