### PR TITLE
Add CoreDNS and VPC CNI as cluster addons to keep them up to date

### DIFF
--- a/core-services/_providers.tf
+++ b/core-services/_providers.tf
@@ -28,6 +28,10 @@ data "aws_eks_cluster_auth" "auth" {
   name = var.md_metadata.name_prefix
 }
 
+data "aws_arn" "cluster" {
+  arn = data.aws_eks_cluster.cluster.arn
+}
+
 provider "aws" {
   region = var.vpc.specs.aws.region
   assume_role {

--- a/core-services/addons.tf
+++ b/core-services/addons.tf
@@ -1,5 +1,6 @@
 locals {
   enable_ebs_csi = true
+  eks_oidc_short = replace(local.oidc_issuer_url, "https://", "")
 }
 
 module "ebs_csi" {
@@ -11,6 +12,22 @@ module "ebs_csi" {
   eks_oidc_issuer_url = local.oidc_issuer_url
 }
 
+// COREDNS
+data "aws_eks_addon_version" "coredns" {
+  addon_name         = "coredns"
+  kubernetes_version = data.aws_eks_cluster.cluster.version
+  most_recent        = true
+}
+
+resource "aws_eks_addon" "coredns" {
+  cluster_name                = data.aws_eks_cluster.cluster.name
+  addon_name                  = "coredns"
+  addon_version               = data.aws_eks_addon_version.coredns.version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+}
+
+// KUBE-PROXY
 data "aws_eks_addon_version" "kube-proxy" {
   addon_name         = "kube-proxy"
   kubernetes_version = data.aws_eks_cluster.cluster.version
@@ -23,4 +40,47 @@ resource "aws_eks_addon" "kube-proxy" {
   addon_version               = data.aws_eks_addon_version.kube-proxy.version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
+}
+
+// VPC CNI
+resource "aws_iam_role" "vpc-cni" {
+  name = "${data.aws_eks_cluster.cluster.name}-vpc-cni"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      "Sid"    = "EksIrsa"
+      "Effect" = "Allow",
+      "Principal" = {
+        "Federated" = "arn:aws:iam::${data.aws_arn.cluster.account}:oidc-provider/${local.eks_oidc_short}"
+      }
+      "Action" = "sts:AssumeRoleWithWebIdentity",
+      "Condition" = {
+        "StringEquals" = {
+          "${local.eks_oidc_short}:sub" = "system:serviceaccount:kube-system:aws-node"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "vpc-cni" {
+  role       = aws_iam_role.vpc-cni.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+data "aws_eks_addon_version" "vpc-cni" {
+  addon_name         = "vpc-cni"
+  kubernetes_version = data.aws_eks_cluster.cluster.version
+  most_recent        = true
+}
+
+resource "aws_eks_addon" "vpc-cni" {
+  cluster_name                = data.aws_eks_cluster.cluster.name
+  addon_name                  = "vpc-cni"
+  addon_version               = data.aws_eks_addon_version.vpc-cni.version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+
+  service_account_role_arn = aws_iam_role.vpc-cni.arn
 }


### PR DESCRIPTION
Convert CoreDNS and VPC CNI to EKS addons so they stay up to date w/ the cluster version.